### PR TITLE
Append the Storm component's task ID to the metric name, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ System wide deployment requires three steps:
 
 ### Notes
 
+#### Topology Name
+
 You can override the topology name used when reporting to statsd by calling:
 
     statsdConfig.put(Config.TOPOLOGY_NAME, "myTopologyName");
@@ -92,6 +94,14 @@ You can override the topology name used when reporting to statsd by calling:
     statsdConfig.put("topology.name", "myTopologyName");
 
 This will be useful if you use versioned topology names (.e.g. appending a timestamp or a version string), but only care to track them as one in statsd.    
+
+#### Statsd Metric Type
+
+You can configure the Statsd metric type to be sent to Statsd with the following property:
+
+    metrics.statsd.metric_type
+
+Allowed values are `counter` (the default) and `gauge`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ You can configure the Statsd metric type to be sent to Statsd with the following
 
 Allowed values are `counter` (the default) and `gauge`.
 
+#### Statsd Metric Name
+
+You can include the Storm Task ID in the Statsd metric name by setting the following property to `true`:
+
+    metrics.statsd.include_task_id
+
 ## License
 
 storm-metrics-statsd

--- a/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
+++ b/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
@@ -46,6 +46,7 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 	public static final String STATSD_PORT = "metrics.statsd.port";
 	public static final String STATSD_PREFIX = "metrics.statsd.prefix";
 	public static final String STATSD_METRIC_TYPE = "metrics.statsd.metric_type";
+	public static final String STATSD_INCLUDE_TASKID = "metrics.statsd.include_task_id";
 
 	enum StatsdMetricType {
 		COUNTER("counter"),
@@ -78,6 +79,7 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 	int statsdPort = 8125;
 	String statsdPrefix = "storm.metrics.";
 	StatsdMetricType statsdMetricType = StatsdMetricType.COUNTER;
+	boolean includeTaskId = false;
 
 	transient StatsDClient statsd;
 
@@ -115,6 +117,10 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 		
 		if (conf.containsKey(STATSD_METRIC_TYPE)) {
 			statsdMetricType = StatsdMetricType.fromString((String) conf.get(STATSD_METRIC_TYPE));
+		}
+		
+		if (conf.containsKey(STATSD_INCLUDE_TASKID)) {
+			includeTaskId = Boolean.parseBoolean((String) conf.get(STATSD_INCLUDE_TASKID));
 		}
 	}
 
@@ -171,8 +177,11 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 		StringBuilder sb = new StringBuilder()
 				.append(clean(taskInfo.srcWorkerHost)).append(".")
 				.append(taskInfo.srcWorkerPort).append(".")
-				.append(clean(taskInfo.srcComponentId)).append(".")
-				.append(taskInfo.srcTaskId).append(".");
+				.append(clean(taskInfo.srcComponentId)).append(".");
+
+		if (includeTaskId) {
+			sb.append(taskInfo.srcTaskId).append(".");
+		}
 
 		int hdrLength = sb.length();
 

--- a/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
+++ b/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
@@ -87,7 +87,7 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 	}
 
 	String clean(String s) {
-		return s.replace('.', '_').replace('/', '_');
+		return s.replace('.', '_').replace('/', '_').replace(':', '_');
 	}
 
 	@Override
@@ -170,7 +170,7 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 
 	public void report(String s, int number) {
 		LOG.debug("reporting: {}={}", s, number);
-		statsd.count(s, number);
+		statsd.recordGaugeValue(s, number);
 	}
 
 	@Override

--- a/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
+++ b/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
@@ -139,7 +139,8 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 		StringBuilder sb = new StringBuilder()
 				.append(clean(taskInfo.srcWorkerHost)).append(".")
 				.append(taskInfo.srcWorkerPort).append(".")
-				.append(clean(taskInfo.srcComponentId)).append(".");
+				.append(clean(taskInfo.srcComponentId)).append(".")
+				.append(taskInfo.srcTaskId).append(".");
 
 		int hdrLength = sb.length();
 


### PR DESCRIPTION
Hi,

This pull request appends the Storm component's task ID to the name of the metric sent to Statsd. 

This is needed in cases of Storm component paralellism, because if a Storm component has multiple instances (tasks) running, each task records it own, separate metric, but the current implementation doesn't differentiate the separate tasks metrics, so the metrics get sent to Statsd under the same name, and then are furtherly aggregated by Statsd into a single metric. I think we need to differentiate the different task's metrics, so I've added the task ID to the metric name that gets sent to Statsd.

See Storm's default `LoggingMetricsConsumer`, which correctly records separate per-task metrics into the log file.
