### PR TITLE
explicitly specified version for maven-compiler-plugin due to maven3 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>


### PR DESCRIPTION
When building project with maven3, this warning is observed.

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.endgame:storm-metrics-statsd:jar:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 49, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This is due to more strict rules in maven3, details [here](http://stackoverflow.com/questions/4123044/maven-3-warnings-about-build-plugins-plugin-version).

Specifying explicit version in pom.xml fixes this.
