### PR TITLE
a workaround for a bug in clojure that'd convert int to long.  

### DIFF
--- a/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
+++ b/src/main/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumer.java
@@ -5,9 +5,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -77,7 +77,7 @@ public class StatsdMetricConsumer implements IMetricsConsumer {
 		}
 
 		if (conf.containsKey(STATSD_PORT)) {
-			statsdPort = (Integer) conf.get(STATSD_PORT);
+			statsdPort = ((Number) conf.get(STATSD_PORT)).intValue();
 		}
 
 		if (conf.containsKey(STATSD_PREFIX)) {

--- a/src/test/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumerTest.java
+++ b/src/test/java/com/endgame/storm/metrics/statsd/StatsdMetricConsumerTest.java
@@ -5,9 +5,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -54,7 +54,8 @@ public class StatsdMetricConsumerTest extends TestCase {
 
 		Map conf = new HashMap();
 		conf.put(StatsdMetricConsumer.STATSD_HOST, "localhost");
-		conf.put(StatsdMetricConsumer.STATSD_PORT, 5555);
+		// Test that storm/clojure would magically convert int to Long
+		conf.put(StatsdMetricConsumer.STATSD_PORT, 5555l);
 		conf.put(StatsdMetricConsumer.STATSD_PREFIX, "my.statsd.prefix");
 		conf.put(Config.TOPOLOGY_NAME, "myTopologyName");
 


### PR DESCRIPTION
This caused an classCast exception being thrown at parseConfig.
related to #8 
